### PR TITLE
change blast_stats.json schema to add new fields

### DIFF
--- a/tap_sailthru/schemas/blast_stats.json
+++ b/tap_sailthru/schemas/blast_stats.json
@@ -70,6 +70,66 @@
         "null"
       ]
     },
+    "rev": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "purchase": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "purchase_first": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "purchase_second": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "purchase_price": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "optout": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "spam": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "hardbounce": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "softbounce": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "view": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
     "confirmed_opens": {
       "type": [
         "integer",
@@ -419,6 +479,18 @@
               "null"
             ]
           },
+          "optout": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "spam": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "hardbounce": {
             "type": [
               "integer",
@@ -578,6 +650,12 @@
                 "null"
               ]
             },
+            "optout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "spam": {
               "type": [
                 "integer",
@@ -633,6 +711,36 @@
               ]
             },
             "beacon": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "rev": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_first": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_second": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_price": {
               "type": [
                 "integer",
                 "null"
@@ -742,6 +850,12 @@
                 "null"
               ]
             },
+            "optout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "spam": {
               "type": [
                 "integer",
@@ -797,6 +911,36 @@
               ]
             },
             "beacon": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "rev": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_first": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_second": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_price": {
               "type": [
                 "integer",
                 "null"
@@ -906,6 +1050,12 @@
                 "null"
               ]
             },
+            "optout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "spam": {
               "type": [
                 "integer",
@@ -961,6 +1111,36 @@
               ]
             },
             "beacon": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "rev": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_first": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_second": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_price": {
               "type": [
                 "integer",
                 "null"
@@ -1070,6 +1250,12 @@
                 "null"
               ]
             },
+            "optout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "spam": {
               "type": [
                 "integer",
@@ -1125,6 +1311,36 @@
               ]
             },
             "beacon": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "rev": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_first": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_second": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_price": {
               "type": [
                 "integer",
                 "null"
@@ -1234,6 +1450,12 @@
                 "null"
               ]
             },
+            "optout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "spam": {
               "type": [
                 "integer",
@@ -1289,6 +1511,36 @@
               ]
             },
             "beacon": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "rev": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_first": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_second": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_price": {
               "type": [
                 "integer",
                 "null"
@@ -1398,6 +1650,12 @@
                 "null"
               ]
             },
+            "optout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "spam": {
               "type": [
                 "integer",
@@ -1453,6 +1711,36 @@
               ]
             },
             "beacon": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "rev": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_first": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_second": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_price": {
               "type": [
                 "integer",
                 "null"
@@ -1562,6 +1850,12 @@
                 "null"
               ]
             },
+            "optout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "spam": {
               "type": [
                 "integer",
@@ -1617,6 +1911,36 @@
               ]
             },
             "beacon": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "rev": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_first": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_second": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "purchase_price": {
               "type": [
                 "integer",
                 "null"
@@ -1722,6 +2046,24 @@
             ]
           },
           "pv": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "hardbounce": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "softbounce": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "view": {
             "type": [
               "integer",
               "null"
@@ -1879,6 +2221,12 @@
               "null"
             ]
           },
+          "optout": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "spam": {
             "type": [
               "integer",
@@ -1934,6 +2282,36 @@
             ]
           },
           "beacon": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "purchase": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "purchase_first": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "purchase_second": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "purchase_price": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "rev": {
             "type": [
               "integer",
               "null"
@@ -2129,6 +2507,12 @@
               "null"
             ]
           },
+          "optout": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "spam": {
             "type": [
               "integer",
@@ -2178,6 +2562,36 @@
             ]
           },
           "beacon": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "purchase": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "purchase_first": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "purchase_second": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "purchase_price": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "rev": {
             "type": [
               "integer",
               "null"

--- a/tap_sailthru/schemas/blast_stats.json
+++ b/tap_sailthru/schemas/blast_stats.json
@@ -5,129 +5,135 @@
   ],
   "properties": {
     "account_name": {
-        "type": [
-          "null",
-          "string"
-        ]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "blast_id": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "count": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "click_total": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "click_multiple_urls": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "open_total": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "pv": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "rev": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "purchase": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "purchase_first": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "purchase_second": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "purchase_price": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "optout": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "spam": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "hardbounce": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "softbounce": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "view": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "confirmed_opens": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "estopens": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "beacon": {
-        "type": [
-          "null",
-          "integer"
-        ]
-    },
-    "click": {
       "type": [
         "null",
         "integer"
+      ]
+    },
+    "count": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "click_total": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "click_multiple_urls": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "real_clicks": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "real_clicks_total": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "real_opens": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "real_opens_total": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "open_total": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "pv": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "confirmed_opens": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "estopens": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "projected_open_rate": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "projected_open_count": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "beacon": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "click": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "nhi_clicks": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "nhi_clicks_total": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "precached_opens": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "precached_opens_total": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "real_and_precached_opens": {
+      "type": [
+        "integer",
+        "null"
       ]
     },
     "beacon_times": {
@@ -210,6 +216,30 @@
               "null",
               "integer"
             ]
+          },
+          "bot_clicks": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "bot_clicks_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_clicks": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_clicks_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         }
       }
@@ -227,56 +257,86 @@
         "properties": {
           "email": {
             "type": [
-              "null",
-              "string"
+              "string",
+              "null"
             ]
           },
           "click_url": {
             "type": [
-              "null",
-              "string"
+              "string",
+              "null"
             ]
           },
           "click_total": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
+            ]
+          },
+          "real_clicks_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "bot_clicks_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "clicks": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_clicks": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "bot_clicks": {
+            "type": [
+              "integer",
+              "null"
             ]
           },
           "open_total": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click_time": {
             "type": [
-              "null",
-              "string"
+              "string",
+              "null"
             ]
           },
           "open_time": {
             "type": [
-              "null",
-              "string"
+              "string",
+              "null"
             ]
           },
           "pv": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "rev": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "score": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           }
         }
@@ -301,80 +361,146 @@
           },
           "count": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click_total": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click_multiple_urls": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
+            ]
+          },
+          "real_clicks": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_clicks_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_opens": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_opens_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "inferred_open": {
+            "type": [
+              "integer",
+              "null"
             ]
           },
           "open_total": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "pv": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
-          "optout": {
+          "hardbounce": {
             "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "spam": {
-            "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "softbounce": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "view": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "confirmed_opens": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "estopens": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
+            ]
+          },
+          "projected_open_rate": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "projected_open_count": {
+            "type": [
+              "integer",
+              "null"
             ]
           },
           "beacon": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
+            ]
+          },
+          "nhi_clicks": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "nhi_clicks_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "precached_opens": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "precached_opens_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_and_precached_opens": {
+            "type": [
+              "integer",
+              "null"
             ]
           }
         }
@@ -394,122 +520,158 @@
           "properties": {
             "count": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click_total": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click_multiple_urls": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "real_clicks": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_clicks_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_opens": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_opens_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "inferred_open": {
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "open_total": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "pv": {
               "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "optout": {
-              "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "spam": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "hardbounce": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "softbounce": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "view": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "name": {
               "type": [
-                "null",
-                "string"
+                "string",
+                "null"
               ]
             },
             "confirmed_opens": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "estopens": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "projected_open_rate": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "projected_open_count": {
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "beacon": {
               "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_price": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "rev": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_first": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_second": {
-              "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "nhi_clicks": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "nhi_clicks_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "precached_opens": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "precached_opens_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_and_precached_opens": {
+              "type": [
+                "integer",
+                "null"
               ]
             }
           }
@@ -522,122 +684,158 @@
           "properties": {
             "count": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click_total": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click_multiple_urls": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "real_clicks": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_clicks_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_opens": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_opens_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "inferred_open": {
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "open_total": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "pv": {
               "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "optout": {
-              "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "spam": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "hardbounce": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "softbounce": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "view": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "name": {
               "type": [
-                "null",
-                "string"
+                "string",
+                "null"
               ]
             },
             "confirmed_opens": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "estopens": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "projected_open_rate": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "projected_open_count": {
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "beacon": {
               "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_price": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "rev": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_first": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_second": {
-              "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "nhi_clicks": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "nhi_clicks_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "precached_opens": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "precached_opens_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_and_precached_opens": {
+              "type": [
+                "integer",
+                "null"
               ]
             }
           }
@@ -650,122 +848,158 @@
           "properties": {
             "count": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click_total": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click_multiple_urls": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "real_clicks": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_clicks_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_opens": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_opens_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "inferred_open": {
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "open_total": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "pv": {
               "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "optout": {
-              "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "spam": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "hardbounce": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "softbounce": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "view": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "name": {
               "type": [
-                "null",
-                "string"
+                "string",
+                "null"
               ]
             },
             "confirmed_opens": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "estopens": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "projected_open_rate": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "projected_open_count": {
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "beacon": {
               "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_price": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "rev": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_first": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_second": {
-              "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "nhi_clicks": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "nhi_clicks_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "precached_opens": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "precached_opens_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_and_precached_opens": {
+              "type": [
+                "integer",
+                "null"
               ]
             }
           }
@@ -778,122 +1012,158 @@
           "properties": {
             "count": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click_total": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click_multiple_urls": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "real_clicks": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_clicks_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_opens": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_opens_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "inferred_open": {
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "open_total": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "pv": {
               "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "optout": {
-              "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "spam": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "hardbounce": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "softbounce": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "view": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "name": {
               "type": [
-                "null",
-                "string"
+                "string",
+                "null"
               ]
             },
             "confirmed_opens": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "estopens": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "projected_open_rate": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "projected_open_count": {
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "beacon": {
               "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_price": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "rev": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_first": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_second": {
-              "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "nhi_clicks": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "nhi_clicks_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "precached_opens": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "precached_opens_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_and_precached_opens": {
+              "type": [
+                "integer",
+                "null"
               ]
             }
           }
@@ -906,122 +1176,158 @@
           "properties": {
             "count": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click_total": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click_multiple_urls": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "real_clicks": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_clicks_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_opens": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_opens_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "inferred_open": {
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "open_total": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "pv": {
               "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "optout": {
-              "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "spam": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "hardbounce": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "softbounce": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "view": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "name": {
               "type": [
-                "null",
-                "string"
+                "string",
+                "null"
               ]
             },
             "confirmed_opens": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "estopens": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "projected_open_rate": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "projected_open_count": {
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "beacon": {
               "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_price": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "rev": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_first": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_second": {
-              "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "nhi_clicks": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "nhi_clicks_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "precached_opens": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "precached_opens_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_and_precached_opens": {
+              "type": [
+                "integer",
+                "null"
               ]
             }
           }
@@ -1034,122 +1340,158 @@
           "properties": {
             "count": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click_total": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click_multiple_urls": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "real_clicks": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_clicks_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_opens": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_opens_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "inferred_open": {
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "open_total": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "pv": {
               "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "optout": {
-              "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "spam": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "hardbounce": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "softbounce": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "view": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "name": {
               "type": [
-                "null",
-                "string"
+                "string",
+                "null"
               ]
             },
             "confirmed_opens": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "estopens": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "projected_open_rate": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "projected_open_count": {
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "beacon": {
               "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_price": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "rev": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_first": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_second": {
-              "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "nhi_clicks": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "nhi_clicks_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "precached_opens": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "precached_opens_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_and_precached_opens": {
+              "type": [
+                "integer",
+                "null"
               ]
             }
           }
@@ -1162,127 +1504,162 @@
           "properties": {
             "count": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click_total": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click_multiple_urls": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "real_clicks": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_clicks_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_opens": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_opens_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "inferred_open": {
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "open_total": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "pv": {
               "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "optout": {
-              "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "spam": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "hardbounce": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "softbounce": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "view": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "name": {
               "type": [
-                "null",
-                "string"
+                "string",
+                "null"
               ]
             },
             "confirmed_opens": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "estopens": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "projected_open_rate": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "projected_open_count": {
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "beacon": {
               "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_price": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "rev": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_first": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "purchase_second": {
-              "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
               ]
             },
             "click": {
               "type": [
-                "null",
-                "integer"
+                "integer",
+                "null"
+              ]
+            },
+            "nhi_clicks": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "nhi_clicks_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "precached_opens": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "precached_opens_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "real_and_precached_opens": {
+              "type": [
+                "integer",
+                "null"
               ]
             }
           }
         }
-
       }
     },
     "signup": {
@@ -1298,74 +1675,128 @@
         "properties": {
           "count": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click_total": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click_multiple_urls": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
+            ]
+          },
+          "real_clicks": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_clicks_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_opens": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_opens_total": {
+            "type": [
+              "integer",
+              "null"
             ]
           },
           "open_total": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "pv": {
             "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "softbounce": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "view": {
-            "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "name": {
             "type": [
-              "null",
-              "string"
+              "string",
+              "null"
             ]
           },
           "confirmed_opens": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "estopens": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
+            ]
+          },
+          "projected_open_rate": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "projected_open_count": {
+            "type": [
+              "integer",
+              "null"
             ]
           },
           "beacon": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
+            ]
+          },
+          "nhi_clicks": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "nhi_clicks_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "precached_opens": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "precached_opens_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_and_precached_opens": {
+            "type": [
+              "integer",
+              "null"
             ]
           }
         }
@@ -1382,124 +1813,166 @@
           "object"
         ],
         "properties": {
+          "subject": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "count": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click_total": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click_multiple_urls": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
+            ]
+          },
+          "real_clicks": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_clicks_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_opens": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_opens_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "inferred_open": {
+            "type": [
+              "integer",
+              "null"
             ]
           },
           "open_total": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "pv": {
             "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "optout": {
-            "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "spam": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "hardbounce": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "softbounce": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "view": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
-          "subject": {
+          "name": {
             "type": [
-              "null",
-              "string"
+              "string",
+              "null"
             ]
           },
           "confirmed_opens": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "estopens": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
+            ]
+          },
+          "projected_open_rate": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "projected_open_count": {
+            "type": [
+              "integer",
+              "null"
             ]
           },
           "beacon": {
             "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "purchase_price": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "rev": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "purchase_first": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "purchase": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "purchase_second": {
-            "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
+            ]
+          },
+          "nhi_clicks": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "nhi_clicks_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "precached_opens": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "precached_opens_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_and_precached_opens": {
+            "type": [
+              "integer",
+              "null"
             ]
           }
         }
@@ -1518,26 +1991,62 @@
         "properties": {
           "url": {
             "type": [
-              "null",
-              "string"
+              "string",
+              "null"
             ]
           },
           "count": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click_total": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
+            ]
+          },
+          "bot_clicks": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "bot_clicks_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_clicks": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_clicks_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "hardbounce": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "softbounce": {
+            "type": [
+              "integer",
+              "null"
             ]
           }
         }
@@ -1554,124 +2063,160 @@
           "object"
         ],
         "properties": {
+          "device": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "count": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click_total": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click_multiple_urls": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
+            ]
+          },
+          "real_clicks": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_clicks_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_opens": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_opens_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "inferred_open": {
+            "type": [
+              "integer",
+              "null"
             ]
           },
           "open_total": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "pv": {
             "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "optout": {
-            "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "spam": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "hardbounce": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "softbounce": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "view": {
             "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "device": {
-            "type": [
-              "null",
-              "string"
+              "integer",
+              "null"
             ]
           },
           "confirmed_opens": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "estopens": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
+            ]
+          },
+          "projected_open_rate": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "projected_open_count": {
+            "type": [
+              "integer",
+              "null"
             ]
           },
           "beacon": {
             "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "purchase_price": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "rev": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "purchase_first": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "purchase": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "purchase_second": {
-            "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
             ]
           },
           "click": {
             "type": [
-              "null",
-              "integer"
+              "integer",
+              "null"
+            ]
+          },
+          "nhi_clicks": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "nhi_clicks_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "precached_opens": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "precached_opens_total": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "real_and_precached_opens": {
+            "type": [
+              "integer",
+              "null"
             ]
           }
         }

--- a/tap_sailthru/streams.py
+++ b/tap_sailthru/streams.py
@@ -205,6 +205,8 @@ class BlastStatsStream(SailthruStream):
     schema_filepath = SCHEMAS_DIR / "blast_stats.json"
     parent_stream_type = BlastStream
     rest_method = "GET"
+    #  we set ignore_parent_replication_key = True here since we'd want the latest stats for each blast. the tradeoff is that the ingestion takes longer.
+    ignore_parent_replication_key = True
 
     def get_url(self, context: Optional[dict]) -> str:
         """Construct url for api request.


### PR DESCRIPTION
Change the `blast_stats.json` schema to add new fields from the documentation [here](https://getstarted.meetmarigold.com/engagebysailthru/Content/developers/api/stats.html?tocpath=Technical%20Documents%7CFor%20Developers%7CAPI%20Endpoints%7C_____18#ReturnValue1)

Ran a test `meltano elt` into `nymag-analytics-157315.dev_meltano.dev_blast_stats` with the new schema